### PR TITLE
Fix: Ensure mobile dropdown menu overlays hero image

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -21,6 +21,7 @@
   overflow: hidden; /* Hides any part of the image that overflows the container */
   text-align: center;
   color: white; /* Text color for the hero text */
+  z-index: 0; /* Establish a stacking context */
 }
 
 /*

--- a/css/styles.css
+++ b/css/styles.css
@@ -192,6 +192,7 @@ nav {
   width: 100%;
   padding: 1rem 0;
   border-bottom: 1px solid var(--secondary-accent);
+  z-index: 1000; /* Ensure it's on top of other content */
 }
 
 /* Individual mobile navigation links */


### PR DESCRIPTION
The mobile dropdown menu was not appearing in front of the hero image because it lacked a `z-index`. This change adds a `z-index` to the `.mobile-nav` class to ensure it has a higher stacking order than the hero image. A `z-index` is also added to the `.hero` class to establish a stacking context.