### PR TITLE
feat: Remove sample gallery from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,33 +115,6 @@
         <!-- Gallery Preview Section -->
         <section class="gallery-preview">
             <h2>Gallery Preview</h2>
-            <div class="preview-grid">
-                <!-- Each item links to a specific work page (placeholders for now) -->
-                <div class="preview-item">
-                    <a href="collections/sample-collection/sample-work/index.html">
-                        <img src="https://placehold.co/400x400/82CFA8/000000?text=Artwork+1"
-                             data-src="images/Macha_Proj3_01.png"
-                             alt="Artwork Preview 1"
-                             class="lazy">
-                    </a>
-                </div>
-                <div class="preview-item">
-                    <a href="collections/sample-collection/sample-work/index.html">
-                        <img src="https://placehold.co/400x400/82CFA8/000000?text=Artwork+2"
-                             data-src="images/Macha_Proj3_02.png"
-                             alt="Artwork Preview 2"
-                             class="lazy">
-                    </a>
-                </div>
-                <div class="preview-item">
-                    <a href="collections/sample-collection/sample-work/index.html">
-                        <img src="https://placehold.co/400x400/82CFA8/000000?text=Artwork+3"
-                             data-src="images/Macha_Proj4_Rubylith.PNG"
-                             alt="Artwork Preview 3"
-                             class="lazy">
-                    </a>
-                </div>
-            </div>
             <div class="gallery-link">
                 <a href="collections/index.html">View Full Gallery</a>
             </div>


### PR DESCRIPTION
This change removes the sample gallery preview from the homepage (`index.html`). The "View Full Gallery" button remains. This is done to simplify the homepage and encourage you to view the full gallery.